### PR TITLE
Register OAuth 2 scheme in API index

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -19,6 +19,7 @@ function bootstrap() {
 	// Core authentication hooks.
 	add_filter( 'determine_current_user', __NAMESPACE__ . '\\Authentication\\attempt_authentication', 11 );
 	add_filter( 'rest_authentication_errors', __NAMESPACE__ . '\\Authentication\\maybe_report_errors' );
+	add_filter( 'rest_index', __NAMESPACE__ . '\\register_in_index' );
 
 	// Internal default hooks.
 	add_filter( 'oauth2.grant_types', __NAMESPACE__ . '\\register_grant_types', 0 );


### PR DESCRIPTION
Adds `.authentication.oauth2` to the index with URLs and detail about supported grant types:
```json
{
	"authentication": {
		"oauth2": {
			"endpoints": {
				"authorization": "http://vagrant.local/wp/wp-login.php?action=oauth2_authorize",
				"token": "http://vagrant.local/wp-json/oauth2/token"
			},
			"grant_types": [
				"authorization_code",
				"implicit"
			]
		}
	},
}
```