### PR TITLE
Testing Infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ node_modules
 # Book build output
 _book
 
+# Composer
+composer.lock
+vendor
+
 # eBook build output
 *.epub
 *.mobi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,6 @@ install:
   - composer install --no-interaction
 
 script:
-  - find src tests \( -name '*.php' \) -exec php -l {} \;
+  - find inc tests theme \( -name '*.php' \) -exec php -l {} \;
+  - php -l plugin.php
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: php
+
+sudo: false
+
+cache:
+  apt: true
+  directories:
+    - $HOME/.composer/cache/files
+
+php:
+  - 5.4
+  - 5.6
+  - 7.0
+  - 7.1
+  - nightly
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - composer self-update
+
+install:
+  - composer install --no-interaction
+
+script:
+  - find src tests \( -name '*.php' \) -exec php -l {} \;
+  - vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # OAuth 2.0 for WordPress
 
+[![Status](https://img.shields.io/badge/status-active-brightgreen.svg)](https://github.com/WP-API/OAuth2)
+[![Build](https://img.shields.io/travis/WP-API/OAuth2.svg)](https://travis-ci.org/WP-API/OAuth2)
+[![License](https://img.shields.io/github/release/WP-API/OAuth2.svg)](https://github.com/WP-API/OAuth2)
+
 Connect applications to your WordPress site without ever giving away your password.
 
 This plugin uses the OAuth 2 protocol to allow delegated authorization; that is, to allow applications to access a site using a set of secondary credentials. This allows server administrators to control which applications can access the site, as well as allowing users to control which applications have access to their data.

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,18 @@
       "name": "WP-API Team",
       "homepage": "http://wp-api.org/"
     }
-  ]
+  ],
+  "require": {
+    "php": ">=5.4"
+  },
+  "require-dev": {
+    "brain/monkey": "^1.5",
+    "mockery/mockery": "~0.9",
+    "phpunit/phpunit": "^4.8|^5.0"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "WP\\OAuth2\\Tests\\": "tests"
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "php": ">=5.4"
   },
   "require-dev": {
+    "antecedent/patchwork": "^2.0",
     "brain/monkey": "^1.5",
     "mockery/mockery": "~0.9",
     "phpunit/phpunit": "^4.8|^5.0"

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,5 @@
+{
+  "redefinable-internals": [
+    "exit"
+  ]
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+	backupGlobals="false"
+	backupStaticAttributes="false"
+	bootstrap="vendor/autoload.php"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	processIsolation="false"
+	stopOnFailure="false">
+	<testsuites>
+		<testsuite name="unit">
+			<directory suffix="Test.php">tests/Unit</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">inc</directory>
+			<directory suffix=".php">theme</directory>
+			<file>plugin.php</file>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace WP\OAuth2\Tests;
+
+use Brain\Monkey;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+/**
+ * Abstract base class for all test case implementations.
+ */
+abstract class TestCase extends PHPUnitTestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/**
+	 * Prepares the test environment before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp() {
+		parent::setUp();
+		Monkey::setUpWP();
+	}
+
+	/**
+	 * Cleans up the test environment after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown() {
+		Monkey::tearDownWP();
+		parent::tearDown();
+	}
+
+	/**
+	 * Loads the given files if they haven't been loaded before.
+	 *
+	 * @param string|string[] $files One or more file paths, relative to the plugin root.
+	 *
+	 * @return void
+	 */
+	protected static function autoload( $files ) {
+		$files = (array) $files;
+		array_walk( $files, [ __CLASS__, 'autoload_file' ] );
+	}
+
+	/**
+	 * Loads the given file if it hasn't been loaded before.
+	 *
+	 * @param string $file File paths, relative to the plugin root.
+	 *
+	 * @return void
+	 */
+	private static function autoload_file( $file ) {
+		static $root_path;
+		if ( ! $root_path ) {
+			$root_path = dirname( __DIR__ ) . '/';
+		}
+		/** @noinspection PhpIncludeInspection */
+		require_once $root_path . trim( $file, '\/' );
+	}
+}

--- a/tests/Unit/Endpoints/AuthorizationTest.php
+++ b/tests/Unit/Endpoints/AuthorizationTest.php
@@ -3,6 +3,8 @@
 namespace WP\OAuth2\Tests\Unit\Endpoints;
 
 use Brain\Monkey;
+use Mockery;
+use Patchwork;
 use WP\OAuth2\Endpoints\Authorization as Testee;
 use WP\OAuth2\Tests\TestCase;
 
@@ -26,7 +28,40 @@ class AuthorizationTest extends TestCase {
 	 */
 	public function test_registering_hooks() {
 		$testee = new Testee();
+
 		Monkey\WP\Actions::expectAdded( 'login_form_' . Testee::LOGIN_ACTION, [ $testee, 'handle_request' ] );
+
+		$testee->register_hooks();
+	}
+
+	/**
+	 * Tests registering all the hooks.
+	 */
+	public function test_using_authorization_handler_for_specified_response_type() {
+		$response_type = 'some-response-type-here';
+		$_GET['response_type'] = $response_type;
+
+		$testee = new Testee();
+
+		Monkey\Functions::when( 'wp_unslash' )->returnArg();
+
+		$handler = Mockery::mock( 'WP\\OAuth2\\Types\Type', [
+			'get_response_type_code' => $response_type,
+		] );
+		$handler->shouldReceive( 'handle_authorisation' )->andReturn( 'no-wp-error' );
+
+		$other_handler = Mockery::mock( 'WP\\OAuth2\\Types\Type', [
+			'get_response_type_code' => 'other-response-type',
+		] );
+
+		Monkey\Functions::expect( 'WP\\OAuth2\\get_grant_types' )->andReturn( [
+			clone $other_handler,
+			$handler,
+			clone $other_handler,
+		] );
+
+		Patchwork\redefine( 'exit', function() {} );
+
 		$testee->register_hooks();
 	}
 }

--- a/tests/Unit/Endpoints/AuthorizationTest.php
+++ b/tests/Unit/Endpoints/AuthorizationTest.php
@@ -1,0 +1,32 @@
+<?php # -*- coding: utf-8 -*-
+
+namespace WP\OAuth2\Tests\Unit\Endpoints;
+
+use Brain\Monkey;
+use WP\OAuth2\Endpoints\Authorization as Testee;
+use WP\OAuth2\Tests\TestCase;
+
+/**
+ * Test class for the authorzation endpoint.
+ */
+class AuthorizationTest extends TestCase {
+
+	/**
+	 * Loads all required files.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::autoload( 'inc/endpoints/class-authorization.php' );
+	}
+
+	/**
+	 * Tests registering all the hooks.
+	 */
+	public function test_registering_hooks() {
+		$testee = new Testee();
+		Monkey\WP\Actions::expectAdded( 'login_form_' . Testee::LOGIN_ACTION, [ $testee, 'handle_request' ] );
+		$testee->register_hooks();
+	}
+}


### PR DESCRIPTION
This pull request resolves issue #25.

#### What's Included in This Pull Request

* Travis CI config file (someone has to set up the integration, I have no rights).
* Updated Composer config file.
* PHPUnit config file.
* Base unit test case class.
* Example test showing off Brain Monkey, Mockery and Patchwork.
* Some nice badges for the readme file.

The example test class absolutely doesn't have to stay that way (well, at least the second method). I just tried to pick something not too complex that allows to leverage all three testing/mocking tools.

**The code requires PHP version 5.4 or higher.**

I didn't get any answers to my question about the targeted PHP version, so I chose what we are currently using - and what is required by all of the testing/mocking methods - PHP 5.4.

Happy to get any feedback.