### PR TITLE
Add convenience redirect for the authorize page

### DIFF
--- a/inc/endpoints/namespace.php
+++ b/inc/endpoints/namespace.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace WP\OAuth2\Endpoints;
+
+use WP\OAuth2;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Register OAuth-specific endpoints.
+ */
+function register() {
+	$token_endpoint = new Token();
+	$token_endpoint->register_routes();
+
+	// Register convenience URL.
+	register_rest_route( 'oauth2', '/authorize', [
+		'methods' => 'GET',
+		'callback' => __NAMESPACE__ . '\\redirect_to_authorize',
+	]);
+}
+
+/**
+ * Handle authorize endpoint request.
+ *
+ * This endpoint exists as a convenience URL to avoid clients needing to find
+ * wp-login.php.
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response Response object.
+ */
+function redirect_to_authorize( WP_REST_Request $request ) {
+	$url = OAuth2\get_authorization_url();
+
+	$query = $request->get_query_params();
+	if ( ! empty( $query ) ) {
+		// Pass query arguments along.
+		$url = add_query_arg(
+			urlencode_deep( $query ),
+			$url
+		);
+	}
+
+	return new WP_REST_Response( [ 'url' => $url ], 302, [ 'Location' => $url ] );
+}

--- a/plugin.php
+++ b/plugin.php
@@ -25,7 +25,7 @@ function bootstrap() {
 	// REST API integration.
 	add_filter( 'rest_authentication_errors', __NAMESPACE__ . '\\Authentication\\maybe_report_errors' );
 	add_filter( 'rest_index', __NAMESPACE__ . '\\register_in_index' );
-	add_action( 'rest_api_init', __NAMESPACE__ . '\\register_routes' );
+	add_action( 'rest_api_init', __NAMESPACE__ . '\\Endpoints\\register' );
 
 	// Internal default hooks.
 	add_filter( 'oauth2.grant_types', __NAMESPACE__ . '\\register_grant_types', 0 );
@@ -40,6 +40,7 @@ function load() {
 	require __DIR__ . '/inc/class-client.php';
 	require __DIR__ . '/inc/class-scopes.php';
 	require __DIR__ . '/inc/authentication/namespace.php';
+	require __DIR__ . '/inc/endpoints/namespace.php';
 	require __DIR__ . '/inc/endpoints/class-authorization.php';
 	require __DIR__ . '/inc/endpoints/class-token.php';
 	require __DIR__ . '/inc/tokens/namespace.php';
@@ -127,11 +128,6 @@ function register_in_index( WP_REST_Response $response ) {
 
 	$response->set_data( $data );
 	return $response;
-}
-
-function register_routes() {
-	$token_endpoint = new Endpoints\Token();
-	$token_endpoint->register_routes();
 }
 
 /**


### PR DESCRIPTION
It's handy to be able to skip reading the index if you're looking to just get it working, instead of worrying about being 100% correct by checking whether OAuth 2 is active.