### PR TITLE
Improve storage mechanisms

### DIFF
--- a/inc/admin/profile/namespace.php
+++ b/inc/admin/profile/namespace.php
@@ -26,6 +26,10 @@ function bootstrap() {
  */
 function render_profile_section( WP_User $user ) {
 	$tokens = Access_Token::get_for_user( $user );
+	$tokens = array_filter( $tokens, function ( Access_Token $token ) {
+		return (bool) $token->get_client();
+	});
+
 	?>
 	<h2><?php _e( 'Authorized Applications', 'oauth2' ) ?></h2>
 	<?php if ( ! empty( $tokens ) ) : ?>

--- a/inc/authentication/namespace.php
+++ b/inc/authentication/namespace.php
@@ -117,9 +117,10 @@ function attempt_authentication( $user = null ) {
 	// Attempt to find the token.
 	$is_querying_token = true;
 	$token = Tokens\get_by_id( $token_value );
+	$client = $token->get_client();
 	$is_querying_token = false;
 
-	if ( empty( $token ) ) {
+	if ( empty( $token ) || empty( $client ) ) {
 		$oauth2_error = create_invalid_token_error( $token_value );
 		return $user;
 	}

--- a/inc/class-client.php
+++ b/inc/class-client.php
@@ -11,7 +11,6 @@ use WP_User;
 
 class Client {
 	const POST_TYPE            = 'oauth2_client';
-	const CLIENT_ID_KEY        = '_oauth2_client_id';
 	const CLIENT_SECRET_KEY    = '_oauth2_client_secret';
 	const TYPE_KEY             = '_oauth2_client_type';
 	const REDIRECT_URI_KEY     = '_oauth2_redirect_uri';
@@ -41,12 +40,7 @@ class Client {
 	 * @return string Client ID.
 	 */
 	public function get_id() {
-		$result = get_post_meta( $this->get_post_id(), static::CLIENT_ID_KEY, false );
-		if ( empty( $result ) ) {
-			return null;
-		}
-
-		return $result[0];
+		return $this->post->post_name;
 	}
 
 	/**
@@ -284,12 +278,9 @@ class Client {
 			'post_status'    => 'publish',
 			'posts_per_page' => 1,
 			'no_found_rows'  => true,
-			'meta_query'     => [
-				[
-					'key'   => static::CLIENT_ID_KEY,
-					'value' => $id,
-				],
-			],
+
+			// Query by slug.
+			'name'           => $id,
 		];
 		$query = new WP_Query( $args );
 		if ( empty( $query->posts ) ) {
@@ -322,10 +313,12 @@ class Client {
 	 * @return WP_Error|Client Client instance on success, error otherwise.
 	 */
 	public static function create( $data ) {
+		$client_id = wp_generate_password( static::CLIENT_ID_LENGTH, false );
 		$post_data = [
 			'post_type'    => static::POST_TYPE,
 			'post_title'   => $data['name'],
 			'post_content' => $data['description'],
+			'post_name'    => $client_id,
 			'post_status'  => 'draft',
 		];
 
@@ -338,7 +331,6 @@ class Client {
 		$meta = [
 			static::REDIRECT_URI_KEY  => $data['meta']['callback'],
 			static::TYPE_KEY          => $data['meta']['type'],
-			static::CLIENT_ID_KEY     => wp_generate_password( static::CLIENT_ID_LENGTH, false ),
 			static::CLIENT_SECRET_KEY => wp_generate_password( static::CLIENT_SECRET_LENGTH, false ),
 		];
 

--- a/inc/tokens/class-access-token.php
+++ b/inc/tokens/class-access-token.php
@@ -66,7 +66,10 @@ class Access_Token extends Token {
 		$args = [
 			'number'      => 1,
 			'count_total' => false,
-			'meta_query'  => [
+
+			// We use an EXISTS query here, limited by 1, so we can ignore
+			// the performance warning.
+			'meta_query'  => [ // WPCS: tax_query OK
 				[
 					'key'     => $key,
 					'compare' => 'EXISTS',


### PR DESCRIPTION
This changes client keys to be stored in the `post_name` for better performing lookups. It also ignores the `meta_query` we use on users; as it's an EXISTS query, it should be fast enough to not be an issue.