### PR TITLE
Validating redirect_uri according to rfc6749 4.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ _book
 *.mobi
 *.pdf
 .idea
+.vscode
+vendor
+composer.lock

--- a/inc/class-client.php
+++ b/inc/class-client.php
@@ -229,8 +229,8 @@ class Client {
 	 *
 	 * @return Authorization_Code|WP_Error
 	 */
-	public function generate_authorization_code( WP_User $user ) {
-		return Authorization_Code::create( $this, $user );
+	public function generate_authorization_code( WP_User $user, $redirect_uri = '' ) {
+		return Authorization_Code::create( $this, $user, $redirect_uri );
 	}
 
 	/**

--- a/inc/endpoints/class-token.php
+++ b/inc/endpoints/class-token.php
@@ -71,7 +71,7 @@ class Token {
 			return $auth_code;
 		}
 
-		$is_valid = $auth_code->validate();
+		$is_valid = $auth_code->validate( [ 'redirect_uri' => $request['redirect_uri'], 'code' => $request['code'] ] );
 		if ( is_wp_error( $is_valid ) ) {
 			// Invalid request, but code itself exists, so we should delete
 			// (and silently ignore errors).

--- a/inc/types/class-authorization-code.php
+++ b/inc/types/class-authorization-code.php
@@ -33,7 +33,8 @@ class Authorization_Code extends Base {
 			case 'authorize':
 				// Generate authorization code and redirect back.
 				$user = wp_get_current_user();
-				$code = $client->generate_authorization_code( $user );
+				$code = $client->generate_authorization_code( $user, $redirect_uri );
+
 				if ( is_wp_error( $code ) ) {
 					return $code;
 				}

--- a/inc/types/class-base.php
+++ b/inc/types/class-base.php
@@ -52,9 +52,12 @@ abstract class Base implements Type {
 		}
 
 		// Validate the redirection URI.
-		$redirect_uri = $this->validate_redirect_uri( $client, $redirect_uri );
-		if ( is_wp_error( $redirect_uri ) ) {
-			return $redirect_uri;
+		if ( ! empty( $redirect_uri ) ) {
+			$redirect_uri = $this->validate_redirect_uri( $client, $redirect_uri );
+
+			if ( is_wp_error( $redirect_uri ) ) {
+				return $redirect_uri;
+			}
 		}
 
 		// Valid parameters, ensure the user is logged in.
@@ -69,8 +72,7 @@ abstract class Base implements Type {
 		}
 
 		// Check nonce.
-		$nonce_action = $this->get_nonce_action( $client );
-		if ( ! wp_verify_nonce( wp_unslash( $_POST['_wpnonce'] ), $none_action ) ) {
+		if ( ! wp_verify_nonce( wp_unslash( $_POST['_wpnonce'] ), $this->get_nonce_action( $client ) ) ) {
 			return new WP_Error(
 				'oauth2.types.authorization_code.handle_authorisation.invalid_nonce',
 				__( 'Invalid nonce.', 'oauth2' )
@@ -106,16 +108,10 @@ abstract class Base implements Type {
 	 */
 	protected function validate_redirect_uri( Client $client, $redirect_uri = null ) {
 		if ( empty( $redirect_uri ) ) {
-			$registered = $client->get_redirect_uris();
-			if ( count( $registered ) !== 1 ) {
-				// Either none registered, or more than one, so error.
-				return new WP_Error(
-					'oauth2.types.authorization_code.handle_authorisation.missing_redirect_uri',
-					__( 'Redirect URI was required, but not found.', 'oauth2' )
-				);
-			}
-
-			$redirect_uri = $registered[0];
+			return new WP_Error(
+				'oauth2.types.authorization_code.handle_authorisation.missing_redirect_uri',
+				__( 'Redirect URI was required, but not found.', 'oauth2' )
+			);
 		} else {
 			if ( ! $client->check_redirect_uri( $redirect_uri ) ) {
 				return new WP_Error(


### PR DESCRIPTION
https://tools.ietf.org/html/rfc6749#section-4.1.3

Check whether redirect_uri matches the one in the initial request;

```validate_redirect_uri``` function does not return a registered callback from the DB anymore, if no redirect_uri has been given, as it is an optional parameter. The name of the function did not explain the behaviour well.