### PR TITLE
Add personal access tokens

### DIFF
--- a/inc/admin/profile/namespace.php
+++ b/inc/admin/profile/namespace.php
@@ -135,18 +135,18 @@ function render_token_row( WP_User $user, Access_Token $token ) {
 	 */
 	$actions = apply_filters( 'oauth2.admin.profile.render_token_row.actions', $actions, $token, $user );
 
-	$name = $client->get_name();
+	$name = sprintf( '<strong>%s</strong>', $client->get_name() );
 	if ( $is_personal ) {
 		$name = sprintf(
-			'%s <em>(%s)</em>',
+			'<strong>%s</strong> <em>(%s)</em>',
 			esc_html( $token_name ),
-			$name
+			$client->get_name()
 		);
 	}
 	?>
 	<tr>
 		<td>
-			<p><strong><?php echo $name ?></strong></p>
+			<p><?php echo $name ?></p>
 			<p><?php echo implode( ' | ', $details ) ?></p>
 		</td>
 		<td style="vertical-align: middle">

--- a/inc/admin/profile/namespace.php
+++ b/inc/admin/profile/namespace.php
@@ -17,6 +17,8 @@ function bootstrap() {
 	add_action( 'all_admin_notices', __NAMESPACE__ . '\\output_profile_messages' );
 	add_action( 'personal_options_update',  __NAMESPACE__ . '\\handle_revocation', 10, 1 );
 	add_action( 'edit_user_profile_update', __NAMESPACE__ . '\\handle_revocation', 10, 1 );
+
+	PersonalTokens\bootstrap();
 }
 
 /**

--- a/inc/admin/profile/namespace.php
+++ b/inc/admin/profile/namespace.php
@@ -120,7 +120,7 @@ function render_token_row( WP_User $user, Access_Token $token ) {
 	$actions = [
 		sprintf(
 			'<button class="button" name="oauth2_revoke" title="%s" value="%s">%s</button>',
-			$button_title,
+			esc_attr( $button_title ),
 			wp_create_nonce( 'oauth2_revoke:' . $token->get_key() ) . ':' . esc_attr( $token->get_key() ),
 			esc_html__( 'Revoke', 'oauth2' )
 		),

--- a/inc/admin/profile/namespace.php
+++ b/inc/admin/profile/namespace.php
@@ -77,7 +77,7 @@ function render_profile_section( WP_User $user ) {
  * Render a single row.
  */
 function render_token_row( WP_User $user, Access_Token $token ) {
-	$client = $token->get_client();
+	$client      = $token->get_client();
 	$is_personal = $client instanceof PersonalClient;
 
 	if ( $is_personal ) {
@@ -106,6 +106,7 @@ function render_token_row( WP_User $user, Access_Token $token ) {
 	// Build actions.
 	if ( $is_personal ) {
 		$button_title = sprintf(
+			/* translators: %s: personal token name */
 			__( 'Revoke personal token "%s"', 'oauth2' ),
 			esc_html( $token_name )
 		);

--- a/inc/admin/profile/namespace.php
+++ b/inc/admin/profile/namespace.php
@@ -5,6 +5,7 @@
 
 namespace WP\OAuth2\Admin\Profile;
 
+use WP\OAuth2\PersonalClient;
 use WP\OAuth2\Tokens\Access_Token;
 use WP_User;
 
@@ -61,6 +62,11 @@ function render_profile_section( WP_User $user ) {
  */
 function render_token_row( WP_User $user, Access_Token $token ) {
 	$client = $token->get_client();
+	$is_personal = $client instanceof PersonalClient;
+
+	if ( $is_personal ) {
+		$token_name = $token->get_meta( 'name', __( 'Unknown Token', 'oauth2' ) );
+	}
 
 	$creation_time = $token->get_creation_time();
 	$details = [
@@ -82,11 +88,19 @@ function render_token_row( WP_User $user, Access_Token $token ) {
 	$details = apply_filters( 'oauth2.admin.profile.render_token_row.details', $details, $token, $user );
 
 	// Build actions.
-	$button_title = sprintf(
-		/* translators: %s: app name */
-		__( 'Revoke access for "%s"', 'oauth2' ),
-		$client->get_name()
-	);
+	if ( $is_personal ) {
+		$button_title = sprintf(
+			__( 'Revoke personal token "%s"', 'oauth2' ),
+			esc_html( $token_name )
+		);
+	} else {
+		$button_title = sprintf(
+			/* translators: %s: app name */
+			__( 'Revoke access for "%s"', 'oauth2' ),
+			$client->get_name()
+		);
+	}
+
 	$actions = [
 		sprintf(
 			'<button class="button" name="oauth2_revoke" title="%s" value="%s">%s</button>',
@@ -104,10 +118,19 @@ function render_token_row( WP_User $user, Access_Token $token ) {
 	 * @param WP_User $user User whose profile is being rendered.
 	 */
 	$actions = apply_filters( 'oauth2.admin.profile.render_token_row.actions', $actions, $token, $user );
+
+	$name = $client->get_name();
+	if ( $is_personal ) {
+		$name = sprintf(
+			'%s <em>(%s)</em>',
+			esc_html( $token_name ),
+			$name
+		);
+	}
 	?>
 	<tr>
 		<td>
-			<p><strong><?php echo $client->get_name() ?></strong></p>
+			<p><strong><?php echo $name ?></strong></p>
 			<p><?php echo implode( ' | ', $details ) ?></p>
 		</td>
 		<td style="vertical-align: middle">

--- a/inc/admin/profile/namespace.php
+++ b/inc/admin/profile/namespace.php
@@ -33,6 +33,12 @@ function render_profile_section( WP_User $user ) {
 		return (bool) $token->get_client();
 	});
 
+	if ( ! IS_PROFILE_PAGE ) {
+		$personal_url = PersonalTokens\get_page_url( [ 'user_id' => $user->ID ] );
+	} else {
+		$personal_url = PersonalTokens\get_page_url();
+	}
+
 	?>
 	<h2><?php _e( 'Authorized Applications', 'oauth2' ) ?></h2>
 	<?php if ( ! empty( $tokens ) ) : ?>
@@ -50,9 +56,19 @@ function render_profile_section( WP_User $user ) {
 			}
 			?>
 			</tbody>
+			<tfoot>
+				<tr>
+					<td colspan="2">
+						<a href="<?php echo esc_url( $personal_url ) ?>">
+							<?php esc_html_e( 'Create personal access token', 'oauth2' ) ?>
+						</a>
+					</td>
+				</tr>
+			</tfoot>
 		</table>
 	<?php else : ?>
 		<p class="description"><?php esc_html_e( 'No applications authorized.', 'oauth2' ) ?></p>
+		<p><a href="<?php echo esc_url( $personal_url ) ?>"><?php esc_html_e( 'Create personal access token', 'oauth2' ) ?></a></p>
 	<?php endif ?>
 	<?php
 }

--- a/inc/admin/profile/personaltokens/namespace.php
+++ b/inc/admin/profile/personaltokens/namespace.php
@@ -4,6 +4,7 @@ namespace WP\OAuth2\Admin\Profile\PersonalTokens;
 
 use WP\OAuth2\PersonalClient;
 use WP\OAuth2\Tokens\Access_Token;
+use WP_Error;
 use WP_User;
 
 const ACCESS_TOKENS_PAGE_SLUG = 'oauth2_personal_tokens';

--- a/inc/admin/profile/personaltokens/namespace.php
+++ b/inc/admin/profile/personaltokens/namespace.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace WP\OAuth2\Admin\Profile\PersonalTokens;
+
+use WP\OAuth2\PersonalClient;
+use WP\OAuth2\Tokens\Access_Token;
+use WP_User;
+
+const ACCESS_TOKENS_PAGE_SLUG = 'oauth2_personal_tokens';
+
+function bootstrap() {
+	// Personal Access Tokens page.
+	add_action( 'admin_action_' . ACCESS_TOKENS_PAGE_SLUG, __NAMESPACE__ . '\\render_page' );
+}
+
+/**
+ * Get the token page URL.
+ *
+ * @return string
+ */
+function get_page_url( $args = [] ) {
+	$url = admin_url( 'profile.php' );
+	$args['action'] = ACCESS_TOKENS_PAGE_SLUG;
+	$url = add_query_arg( urlencode_deep( $args ), $url );
+	return $url;
+}
+
+/**
+ * Bootstrap the profile page.
+ *
+ * This sets up the globals for the user page.
+ */
+function bootstrap_profile_page() {
+	global $user_id, $submenu_file, $parent_file;
+	$user_id = null;
+	if ( ! empty( $_REQUEST['user_id'] ) ) {
+		$user_id = (int) $_REQUEST['user_id'];
+	}
+
+	$current_user = wp_get_current_user();
+	if ( ! defined( 'IS_PROFILE_PAGE' ) ) {
+		define( 'IS_PROFILE_PAGE', ( $user_id == $current_user->ID ) );
+	}
+
+	if ( ! $user_id && IS_PROFILE_PAGE ) {
+		$user_id = $current_user->ID;
+	}
+
+	$user = get_user_by( 'id', $user_id );
+	if ( empty( $user ) ) {
+		wp_die( __( 'Invalid user ID.' ) );
+	}
+	if ( ! current_user_can( 'edit_user', $user_id ) ) {
+		wp_die( __( 'Sorry, you are not allowed to edit this user.' ) );
+	}
+
+	if ( current_user_can('edit_users') && ! IS_PROFILE_PAGE ) {
+		$submenu_file = 'users.php';
+	} else {
+		$submenu_file = 'profile.php';
+	}
+
+	if ( current_user_can( 'edit_users' ) ) {
+		$parent_file = 'users.php';
+	} else {
+		$parent_file = 'profile.php';
+	}
+}
+
+/**
+ * Render the access token creation page.
+ */
+function render_page() {
+	bootstrap_profile_page();
+
+	$user = get_user_by( 'id', $GLOBALS['user_id'] );
+
+	if ( isset( $_POST['oauth2_action'] ) ) {
+		$error = handle_page_action( $user );
+
+		if ( is_wp_error( $error ) ) {
+			add_action( 'all_admin_notices', function () use ( $error ) {
+				echo '<div class="error"><p>' . esc_html( $error->get_error_message() ) . '</p></div>';
+			} );
+		}
+	}
+
+	$GLOBALS['title'] = __( 'Personal Access Tokens', 'oauth2' );
+	require ABSPATH . 'wp-admin/admin-header.php';
+
+	$tokens = Access_Token::get_for_user( $user );
+	$tokens = array_filter( $tokens, function ( Access_Token $token ) {
+		$client = $token->get_client();
+		return ! empty( $client ) && $client instanceof PersonalClient;
+	});
+	?>
+	<div class="wrap" id="profile-page">
+		<h1><?php esc_html_e( 'Create a Personal Access Token', 'oauth2' ) ?></h1>
+
+		<p><?php esc_html_e( "The WordPress API allows access to your site by external applications. Personal access tokens allow easy access for personal scripts, command line utilities, or during development. Generally, you shouldn't provide these to applications you don't trust, and you should treat them just like passwords.", 'oauth2' ) ?></p>
+
+		<form action="" method="POST">
+			<table class="form-table">
+				<tr>
+					<th scope="row">
+						<label for="token-name">Token name</label>
+					</th>
+					<td>
+						<input
+							class="regular-text"
+							id="token-name"
+							name="name"
+							required="required"
+							type="text"
+						/>
+
+						<p class="description"><?php esc_html_e( 'Give this token a name so you can easily identify it later.', 'oauth2' ) ?></p>
+					</td>
+				</tr>
+			</table>
+
+			<input type="hidden" name="oauth2_action" value="create" />
+
+			<?php wp_nonce_field( 'oauth2_personal_tokens.create' ) ?>
+
+			<p class="buttons">
+				<button class="button-primary"><?php esc_html_e( 'Generate Token', 'oauth2' ) ?></button>
+			</p>
+		</form>
+	</div>
+	<?php
+	require ABSPATH . 'wp-admin/admin-footer.php';
+	exit;
+}
+
+/**
+ * Handle action from a form.
+ */
+function handle_page_action( WP_User $user ) {
+	$action = $_POST['oauth2_action'];
+
+	switch ( $action ) {
+		case 'create':
+			check_admin_referer( 'oauth2_personal_tokens.create' );
+			$data = wp_unslash( $_POST );
+			return handle_create( $user, $data );
+
+		default:
+			return new WP_Error();
+	}
+}
+
+/**
+ * Handle token creation
+ */
+function handle_create( WP_User $user, $data ) {
+	$client = PersonalClient::get_instance();
+	$meta = [
+		'name' => sanitize_text_field( $data['name'] ),
+	];
+	$token = $client->issue_token( $user, $meta );
+
+	render_create_success( $user, $token );
+}
+
+function render_create_success( WP_User $user, $token ) {
+	$GLOBALS['title'] = __( 'Personal Access Tokens', 'oauth2' );
+	require ABSPATH . 'wp-admin/admin-header.php';
+	?>
+
+	<div class="wrap" id="profile-page">
+		<h1><?php esc_html_e( 'Token created!', 'oauth2' ) ?></h1>
+		<p><?php esc_html_e( "Your token has been created. Make sure to copy it now, as it won't be displayed again!", 'oauth2' ) ?></p>
+
+		<pre style="font-size: 2em"><?php echo esc_html( $token->get_key() ) ?></pre>
+
+		<p><a href="<?php echo esc_url( get_page_url() ) ?>"><?php esc_html_e( 'Back to tokens', 'oauth2' ) ?></a></p>
+	</div>
+
+	<?php
+	require ABSPATH . 'wp-admin/admin-footer.php';
+	exit;
+}

--- a/inc/admin/profile/personaltokens/namespace.php
+++ b/inc/admin/profile/personaltokens/namespace.php
@@ -39,7 +39,7 @@ function bootstrap_profile_page() {
 
 	$current_user = wp_get_current_user();
 	if ( ! defined( 'IS_PROFILE_PAGE' ) ) {
-		define( 'IS_PROFILE_PAGE', ( $user_id == $current_user->ID ) );
+		define( 'IS_PROFILE_PAGE', $user_id === $current_user->ID );
 	}
 
 	if ( ! $user_id && IS_PROFILE_PAGE ) {
@@ -54,7 +54,7 @@ function bootstrap_profile_page() {
 		wp_die( __( 'Sorry, you are not allowed to edit this user.' ) );
 	}
 
-	if ( current_user_can('edit_users') && ! IS_PROFILE_PAGE ) {
+	if ( current_user_can( 'edit_users' ) && ! IS_PROFILE_PAGE ) {
 		$submenu_file = 'users.php';
 	} else {
 		$submenu_file = 'profile.php';

--- a/inc/admin/profile/personaltokens/namespace.php
+++ b/inc/admin/profile/personaltokens/namespace.php
@@ -75,7 +75,7 @@ function render_page() {
 
 	$user = get_user_by( 'id', $GLOBALS['user_id'] );
 
-	if ( isset( $_POST['oauth2_action'] ) ) {
+	if ( isset( $_POST['oauth2_action'] ) ) { // WPCS: CSRF OK
 		$error = handle_page_action( $user );
 
 		if ( is_wp_error( $error ) ) {
@@ -137,7 +137,7 @@ function render_page() {
  * Handle action from a form.
  */
 function handle_page_action( WP_User $user ) {
-	$action = $_POST['oauth2_action'];
+	$action = $_POST['oauth2_action']; // WPCS: CSRF OK
 
 	switch ( $action ) {
 		case 'create':

--- a/inc/admin/profile/personaltokens/namespace.php
+++ b/inc/admin/profile/personaltokens/namespace.php
@@ -185,7 +185,7 @@ function render_create_success( WP_User $user, $token ) {
 
 		<pre style="font-size: 2em"><?php echo esc_html( $token->get_key() ) ?></pre>
 
-		<p><a href="<?php echo esc_url( get_page_url() ) ?>"><?php esc_html_e( 'Back to tokens', 'oauth2' ) ?></a></p>
+		<p><a href="<?php echo esc_url( get_edit_user_link( $user->ID ) ) ?>"><?php esc_html_e( 'Back to profile', 'oauth2' ) ?></a></p>
 	</div>
 
 	<?php

--- a/inc/admin/profile/personaltokens/namespace.php
+++ b/inc/admin/profile/personaltokens/namespace.php
@@ -153,7 +153,10 @@ function handle_page_action( WP_User $user ) {
 			return handle_create( $user, $name );
 
 		default:
-			return new WP_Error();
+			return new WP_Error(
+				'rest_oauth2_invalid_action',
+				__( 'Invalid action.', 'oauth2' )
+			);
 	}
 }
 

--- a/inc/admin/profile/personaltokens/namespace.php
+++ b/inc/admin/profile/personaltokens/namespace.php
@@ -142,8 +142,15 @@ function handle_page_action( WP_User $user ) {
 	switch ( $action ) {
 		case 'create':
 			check_admin_referer( 'oauth2_personal_tokens.create' );
-			$data = wp_unslash( $_POST );
-			return handle_create( $user, $data );
+			if ( empty( $_POST['name'] ) ) {
+				return new WP_Error(
+					'rest_oauth2_missing_name',
+					__( 'Missing name for personal access token.', 'oauth2' )
+				);
+			}
+
+			$name = sanitize_text_field( wp_unslash( $_POST['name'] ) );
+			return handle_create( $user, $name );
 
 		default:
 			return new WP_Error();
@@ -153,10 +160,10 @@ function handle_page_action( WP_User $user ) {
 /**
  * Handle token creation
  */
-function handle_create( WP_User $user, $data ) {
+function handle_create( WP_User $user, $name ) {
 	$client = PersonalClient::get_instance();
 	$meta = [
-		'name' => sanitize_text_field( $data['name'] ),
+		'name' => $name,
 	];
 	$token = $client->issue_token( $user, $meta );
 

--- a/inc/admin/profile/personaltokens/namespace.php
+++ b/inc/admin/profile/personaltokens/namespace.php
@@ -20,9 +20,9 @@ function bootstrap() {
  * @return string
  */
 function get_page_url( $args = [] ) {
-	$url = admin_url( 'profile.php' );
+	$url            = admin_url( 'profile.php' );
 	$args['action'] = ACCESS_TOKENS_PAGE_SLUG;
-	$url = add_query_arg( urlencode_deep( $args ), $url );
+	$url            = add_query_arg( urlencode_deep( $args ), $url );
 	return $url;
 }
 
@@ -34,7 +34,7 @@ function get_page_url( $args = [] ) {
 function bootstrap_profile_page() {
 	global $user_id, $submenu_file, $parent_file;
 	$user_id = null;
-	if ( ! empty( $_REQUEST['user_id'] ) ) {
+	if ( ! empty( $_REQUEST['user_id'] ) ) { // WPCS: CSRF OK
 		$user_id = (int) $_REQUEST['user_id'];
 	}
 
@@ -166,10 +166,10 @@ function handle_page_action( WP_User $user ) {
  */
 function handle_create( WP_User $user, $name ) {
 	$client = PersonalClient::get_instance();
-	$meta = [
+	$meta   = [
 		'name' => $name,
 	];
-	$token = $client->issue_token( $user, $meta );
+	$token  = $client->issue_token( $user, $meta );
 
 	render_create_success( $user, $token );
 }

--- a/inc/class-client.php
+++ b/inc/class-client.php
@@ -9,7 +9,7 @@ use WP_Post;
 use WP_Query;
 use WP_User;
 
-class Client {
+class Client implements ClientInterface {
 	const POST_TYPE            = 'oauth2_client';
 	const CLIENT_SECRET_KEY    = '_oauth2_client_secret';
 	const TYPE_KEY             = '_oauth2_client_type';

--- a/inc/class-client.php
+++ b/inc/class-client.php
@@ -259,11 +259,12 @@ class Client implements ClientInterface {
 	 * Issue token for a user.
 	 *
 	 * @param \WP_User $user
+	 * @param array $meta
 	 *
 	 * @return Access_Token
 	 */
-	public function issue_token( WP_User $user ) {
-		return Tokens\Access_Token::create( $this, $user );
+	public function issue_token( WP_User $user, $meta = [] ) {
+		return Tokens\Access_Token::create( $this, $user, $meta );
 	}
 
 	/**

--- a/inc/class-clientinterface.php
+++ b/inc/class-clientinterface.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace WP\OAuth2;
+
+use WP_User;
+
+interface ClientInterface {
+	/**
+	 * Get the client's ID.
+	 *
+	 * @return string Client ID.
+	 */
+	public function get_id();
+
+	/**
+	 * Get the client's name.
+	 *
+	 * @return string HTML string.
+	 */
+	public function get_name();
+
+	/**
+	 * Get the client's description.
+	 *
+	 * @param boolean $raw True to get raw database value for editing, false to get rendered value for display.
+	 * @return string
+	 */
+	public function get_description( $raw = false );
+
+	/**
+	 * Get the client's type.
+	 *
+	 * @return string Type ID if available, or an empty string.
+	 */
+	public function get_type();
+
+	/**
+	 * Get the Client Secret Key.
+	 *
+	 * @return string The Secret Key if available, or an empty string.
+	 */
+	public function get_secret();
+
+	/**
+	 * Get registered URI for the client.
+	 *
+	 * @return array List of valid redirect URIs.
+	 */
+	public function get_redirect_uris();
+
+	/**
+	 * Check if a redirect URI is valid for the client.
+	 *
+	 * @todo Implement this properly :)
+	 *
+	 * @param string $uri Supplied redirect URI to check.
+	 * @return boolean True if the URI is valid, false otherwise.
+	 */
+	public function check_redirect_uri( $uri );
+
+	/**
+	 * @param WP_User $user
+	 *
+	 * @return Authorization_Code|WP_Error
+	 */
+	public function generate_authorization_code( WP_User $user );
+
+	/**
+	 * Get data stored for an authorization code.
+	 *
+	 * @param string $code Authorization code to fetch.
+	 * @return Authorization_Code|WP_Error Data if available, error if invalid code.
+	 */
+	public function get_authorization_code( $code );
+
+	/**
+	 * @return bool|WP_Error
+	 */
+	public function regenerate_secret();
+
+	/**
+	 * Issue token for a user.
+	 *
+	 * @param \WP_User $user
+	 * @param array $meta
+	 *
+	 * @return Access_Token
+	 */
+	public function issue_token( WP_User $user, $meta = [] );
+
+	/**
+	 * @param array $data
+	 *
+	 * @return WP_Error|Client Client instance on success, error otherwise.
+	 */
+	public function update( $data );
+
+	/**
+	 * Delete the client.
+	 *
+	 * @return bool
+	 */
+	public function delete();
+
+	/**
+	 * Approve a client.
+	 *
+	 * @return bool|WP_Error True if client was updated, error otherwise.
+	 */
+	public function approve();
+}

--- a/inc/class-personalclient.php
+++ b/inc/class-personalclient.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace WP\OAuth2;
+
+use WP\OAuth2\Tokens\Access_Token;
+use WP_Error;
+use WP_User;
+
+/**
+ * Internal client that owns Personal Access Tokens.
+ */
+class PersonalClient implements ClientInterface {
+	/**
+	 * Internal ID for the client.
+	 */
+	const ID = '__personal_access_token';
+
+	/**
+	 * Constructor.
+	 *
+	 * This should always be accessed via {@see get_instance} instead.
+	 */
+	protected function __construct() {
+		// No-op.
+	}
+
+	/**
+	 * Get Personal Access Token client instance.
+	 *
+	 * This is a singleton instance, as it is a fake client backing personal
+	 * access tokens.
+	 *
+	 * @return static
+	 */
+	public static function get_instance() {
+		static $instance;
+		if ( empty( $instance ) ) {
+			$instance = new static();
+		}
+		return $instance;
+	}
+
+	/**
+	 * Get the client's ID.
+	 *
+	 * @return string Client ID.
+	 */
+	public function get_id() {
+		return static::ID;
+	}
+
+	/**
+	 * Get the client's name.
+	 *
+	 * @return string HTML string.
+	 */
+	public function get_name() {
+		return __( 'Personal Access Token', 'oauth2' );
+	}
+
+	/**
+	 * Get the client's description.
+	 *
+	 * @param boolean $raw True to get raw database value for editing, false to get rendered value for display.
+	 * @return string
+	 */
+	public function get_description( $raw = false ) {
+		return __( 'Personal access token manually created by the user.', 'oauth2' );
+	}
+
+	/**
+	 * Get the client's type.
+	 *
+	 * @return string Type ID if available, or an empty string.
+	 */
+	public function get_type() {
+		return 'private';
+	}
+
+	/**
+	 * Get the Client Secret Key.
+	 *
+	 * @return string The Secret Key if available, or an empty string.
+	 */
+	public function get_secret() {
+		return '';
+	}
+
+	/**
+	 * Get registered URI for the client.
+	 *
+	 * @return array List of valid redirect URIs.
+	 */
+	public function get_redirect_uris() {
+		return [];
+	}
+
+	/**
+	 * Check if a redirect URI is valid for the client.
+	 *
+	 * @param string $uri Supplied redirect URI to check.
+	 * @return boolean Always false: personal tokens do not support redirections.
+	 */
+	public function check_redirect_uri( $uri ) {
+		return false;
+	}
+
+	/**
+	 * @param WP_User $user
+	 *
+	 * @return Authorization_Code|WP_Error
+	 */
+	public function generate_authorization_code( WP_User $user ) {
+		return new WP_Error(
+			'oauth2.personalclient.no_auth_code',
+			__( 'Personal Access Tokens do not support authorization codes.', 'oauth2' )
+		);
+	}
+
+	/**
+	 * Get data stored for an authorization code.
+	 *
+	 * @param string $code Authorization code to fetch.
+	 * @return Authorization_Code|WP_Error Data if available, error if invalid code.
+	 */
+	public function get_authorization_code( $code ) {
+		return new WP_Error(
+			'oauth2.personalclient.no_auth_code',
+			__( 'Personal Access Tokens do not support authorization codes.', 'oauth2' )
+		);
+	}
+
+	/**
+	 * @return bool|WP_Error
+	 */
+	public function regenerate_secret() {
+		return new WP_Error(
+			'oauth2.personalclient.no_secrets',
+			__( 'Personal Access Tokens do not support secrets.', 'oauth2' )
+		);
+	}
+
+	/**
+	 * Issue token for a user.
+	 *
+	 * @param \WP_User $user
+	 * @param array $meta
+	 *
+	 * @return Access_Token
+	 */
+	public function issue_token( WP_User $user, $meta = [] ) {
+		return Access_Token::create( $this, $user, $meta );
+	}
+
+	/**
+	 * @param array $data
+	 *
+	 * @return WP_Error|Client Client instance on success, error otherwise.
+	 */
+	public function update( $data ) {
+		return new WP_Error(
+			'oauth2.personalclient.no_update',
+			__( 'Personal Access Tokens cannot be updated.', 'oauth2' )
+		);
+	}
+
+	/**
+	 * Delete the client.
+	 *
+	 * @return bool
+	 */
+	public function delete() {
+		return false;
+	}
+
+	/**
+	 * Approve a client.
+	 *
+	 * @return bool|WP_Error True if client was updated, error otherwise.
+	 */
+	public function approve() {
+		return new WP_Error(
+			'oauth2.personalclient.no_approved',
+			__( 'Personal Access Tokens do not have an approval status.', 'oauth2' )
+		);
+	}
+}

--- a/inc/endpoints/class-token.php
+++ b/inc/endpoints/class-token.php
@@ -4,7 +4,7 @@ namespace WP\OAuth2\Endpoints;
 
 use WP_Error;
 use WP_Http;
-use WP\OAuth2\Client;
+use WP\OAuth2;
 use WP_REST_Request;
 
 /**
@@ -54,7 +54,7 @@ class Token {
 	 * @return array|WP_Error Token data on success, or error on failure.
 	 */
 	public function exchange_token( WP_REST_Request $request ) {
-		$client = Client::get_by_id( $request['client_id'] );
+		$client = OAuth2\get_client( $request['client_id'] );
 		if ( empty( $client ) ) {
 			return new WP_Error(
 				'oauth2.endpoints.token.exchange_token.invalid_client',

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -131,3 +131,13 @@ function get_token_url() {
 	 */
 	return apply_filters( 'oauth2.get_token_url', $url );
 }
+
+/**
+ * Get a client by ID.
+ *
+ * @param string $id ID for the client.
+ * @return ClientInterface Client instance.
+ */
+function get_client( $id ) {
+	return Client::get_by_id( $id );
+}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -139,5 +139,9 @@ function get_token_url() {
  * @return ClientInterface Client instance.
  */
 function get_client( $id ) {
+	if ( $id === PersonalClient::ID ) {
+		return PersonalClient::get_instance();
+	}
+
 	return Client::get_by_id( $id );
 }

--- a/inc/tokens/class-access-token.php
+++ b/inc/tokens/class-access-token.php
@@ -3,7 +3,8 @@
 namespace WP\OAuth2\Tokens;
 
 use WP_Error;
-use WP\OAuth2\Client;
+use WP\OAuth2;
+use WP\OAuth2\ClientInterface;
 use WP_User;
 use WP_User_Query;
 
@@ -21,10 +22,10 @@ class Access_Token extends Token {
 	/**
 	 * Get client for the token.
 	 *
-	 * @return Client|null
+	 * @return ClientInterface|null
 	 */
 	public function get_client() {
-		return Client::get_by_id( $this->value['client'] );
+		return OAuth2\get_client( $this->value['client'] );
 	}
 
 	/**
@@ -119,7 +120,7 @@ class Access_Token extends Token {
 	 *
 	 * @return Access_Token|WP_Error Token instance, or error on failure.
 	 */
-	public static function create( Client $client, WP_User $user ) {
+	public static function create( ClientInterface $client, WP_User $user, $meta = [] ) {
 		if ( ! $user->exists() ) {
 			return new WP_Error(
 				'oauth2.tokens.access_token.create.no_user',

--- a/inc/tokens/class-access-token.php
+++ b/inc/tokens/class-access-token.php
@@ -38,6 +38,43 @@ class Access_Token extends Token {
 	}
 
 	/**
+	 * Get a meta value for the token.
+	 *
+	 * This is used to store additional information on the token itself, such
+	 * as a description for the token.
+	 *
+	 * @param string $key Meta key to fetch.
+	 * @param mixed $default Value to return if key is unavailable.
+	 * @return mixed Value if available, or value of `$default` if not found.
+	 */
+	public function get_meta( $key, $default = null ) {
+		if ( empty( $this->value['meta'] ) || ! isset( $this->value['meta'][ $key ] ) ) {
+			return null;
+		}
+
+		return $this->value['meta'][ $key ];
+	}
+
+	/**
+	 * Set a meta value for the token.
+	 *
+	 * This is used to store additional information on the token itself, such
+	 * as a description for the token.
+	 *
+	 * @param string $key Meta key to set.
+	 * @param mixed $value Value to set on the key.
+	 * @return bool True if meta was set, false otherwise.
+	 */
+	public function set_meta( $key, $value ) {
+		if ( empty( $this->value['meta'] ) ) {
+			$this->value['meta'] = [];
+		}
+		$this->value['meta'][ $key ] = $value;
+
+		return update_user_meta( $this->get_user_id(), wp_slash( $this->get_meta_key() ), wp_slash( $this->value ) );
+	}
+
+	/**
 	 * Revoke the token.
 	 *
 	 * @internal This may return other error codes in the future, as we may
@@ -131,6 +168,7 @@ class Access_Token extends Token {
 		$data = [
 			'client'  => $client->get_id(),
 			'created' => time(),
+			'meta'    => $meta,
 		];
 		$key = wp_generate_password( static::KEY_LENGTH, false );
 		$meta_key = static::META_PREFIX . $key;

--- a/plugin.php
+++ b/plugin.php
@@ -11,6 +11,7 @@
 namespace WP\OAuth2;
 
 require __DIR__ . '/inc/namespace.php';
+require __DIR__ . '/inc/class-clientinterface.php';
 require __DIR__ . '/inc/class-client.php';
 require __DIR__ . '/inc/class-scopes.php';
 require __DIR__ . '/inc/authentication/namespace.php';

--- a/plugin.php
+++ b/plugin.php
@@ -13,6 +13,7 @@ namespace WP\OAuth2;
 require __DIR__ . '/inc/namespace.php';
 require __DIR__ . '/inc/class-clientinterface.php';
 require __DIR__ . '/inc/class-client.php';
+require __DIR__ . '/inc/class-personalclient.php';
 require __DIR__ . '/inc/class-scopes.php';
 require __DIR__ . '/inc/authentication/namespace.php';
 require __DIR__ . '/inc/endpoints/namespace.php';

--- a/plugin.php
+++ b/plugin.php
@@ -29,5 +29,6 @@ require __DIR__ . '/inc/types/class-authorization-code.php';
 require __DIR__ . '/inc/types/class-implicit.php';
 require __DIR__ . '/inc/admin/namespace.php';
 require __DIR__ . '/inc/admin/profile/namespace.php';
+require __DIR__ . '/inc/admin/profile/personaltokens/namespace.php';
 
 bootstrap();


### PR DESCRIPTION
Fixes #11.

This is an alternative approach to @almirbi's PR #43. Rather than issuing tokens for a specific app, it creates a fake/internal client which can only have tokens issued manually via a form (not via the regular OAuth 2 flow).

It adds a new page linked from a user's profile to create these:

<img width="1043" alt="screenshot 2017-09-09 17 17 24" src="https://user-images.githubusercontent.com/21655/30238075-239c8dba-9583-11e7-9cf6-7f5e2f0532c2.png">

It then displays the token's name in the token list on the user's profile, similar to client names:

<img width="1095" alt="screenshot 2017-09-09 17 17 34" src="https://user-images.githubusercontent.com/21655/30238080-37a396be-9583-11e7-99fb-82d37e3eb167.png">
