### PR TITLE
Check $token before using it

### DIFF
--- a/inc/authentication/namespace.php
+++ b/inc/authentication/namespace.php
@@ -117,6 +117,12 @@ function attempt_authentication( $user = null ) {
 	// Attempt to find the token.
 	$is_querying_token = true;
 	$token             = Tokens\get_by_id( $token_value );
+	if ( empty( $token ) ) {
+		$is_querying_token = false;
+		$oauth2_error = create_invalid_token_error( $token_value );
+		return $user;
+	}
+
 	$client            = $token->get_client();
 	$is_querying_token = false;
 


### PR DESCRIPTION
We need to check `$token` is actually usable before we use it.