### PR TITLE
Switch wp_safe_redirect back to wp_redirect

### DIFF
--- a/inc/types/class-authorization-code.php
+++ b/inc/types/class-authorization-code.php
@@ -73,7 +73,8 @@ class Authorization_Code extends Base {
 		);
 
 		$generated_redirect = add_query_arg( urlencode_deep( $redirect_args ), $redirect_uri );
-		wp_safe_redirect( $generated_redirect );
+		// phpcs:ignore WordPress.Security.SafeRedirectSniff -- Intentionally external redirect, secured via client registration.
+		wp_redirect( $generated_redirect );
 		exit;
 	}
 }

--- a/inc/types/class-authorization-code.php
+++ b/inc/types/class-authorization-code.php
@@ -73,7 +73,7 @@ class Authorization_Code extends Base {
 		);
 
 		$generated_redirect = add_query_arg( urlencode_deep( $redirect_args ), $redirect_uri );
-		// phpcs:ignore WordPress.Security.SafeRedirectSniff -- Intentionally external redirect, secured via client registration.
+		// phpcs:ignore WordPress.Security.SafeRedirect -- Intentionally external redirect, secured via client registration.
 		wp_redirect( $generated_redirect );
 		exit;
 	}


### PR DESCRIPTION
This redirect is *intentionally* open, so must use the regular redirect function.

This was inadvertently broken as part of #58.