### PR TITLE
Add per-client token TTL and expiry support for client credentials

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -175,6 +175,16 @@ function validate_parameters( $params ) {
 
 	$valid['client_credentials_enabled'] = ! empty( $params['client_credentials_enabled'] );
 
+	if ( isset( $params['token_ttl'] ) && $params['token_ttl'] !== '' ) {
+		$ttl = (int) $params['token_ttl'];
+		if ( $ttl < 0 ) {
+			return new WP_Error( 'rest_oauth2_invalid_ttl', esc_html__( 'Token TTL must be a positive number or empty for no expiry.', 'oauth2' ) );
+		}
+		$valid['token_ttl'] = $ttl;
+	} else {
+		$valid['token_ttl'] = '';
+	}
+
 	// Callback is required unless this client only uses client_credentials.
 	if ( empty( $params['callback'] ) && ! $valid['client_credentials_enabled'] ) {
 		return new WP_Error( 'rest_oauth2_missing_callback', esc_html__( 'Client callback is required and must be a valid URL.', 'oauth2' ) );
@@ -219,6 +229,7 @@ function handle_edit_submit( Client $consumer = null ) {
 				'type'                       => $params['type'],
 				'callback'                   => $params['callback'],
 				'client_credentials_enabled' => $params['client_credentials_enabled'],
+				'token_ttl'                  => $params['token_ttl'],
 			],
 		];
 
@@ -233,6 +244,7 @@ function handle_edit_submit( Client $consumer = null ) {
 				'type'                       => $params['type'],
 				'callback'                   => $params['callback'],
 				'client_credentials_enabled' => $params['client_credentials_enabled'],
+				'token_ttl'                  => $params['token_ttl'],
 			],
 		];
 
@@ -326,12 +338,14 @@ function render_edit_page() {
 			$data[ $key ] = empty( $form_data[ $key ] ) ? '' : $form_data[ $key ];
 		}
 		$data['client_credentials_enabled'] = ! empty( $form_data['client_credentials_enabled'] );
+		$data['token_ttl']                  = isset( $form_data['token_ttl'] ) ? $form_data['token_ttl'] : '';
 	} else {
 		$data['name']                       = $consumer->get_name();
 		$data['description']                = $consumer->get_description( true );
 		$data['type']                       = $consumer->get_type();
 		$data['callback']                   = $consumer->get_redirect_uris();
 		$data['client_credentials_enabled'] = $consumer->is_client_credentials_enabled();
+		$data['token_ttl']                  = $consumer->get_token_ttl();
 
 		if ( is_array( $data['callback'] ) ) {
 			$data['callback'] = implode( ',', $data['callback'] );
@@ -455,6 +469,15 @@ function render_edit_page() {
 						<p class="description">
 							<?php esc_html_e( 'When enabled, this application can authenticate without a user using its client ID and secret. Use for machine-to-machine integrations only. Tokens issued this way are not associated with a WordPress user.', 'oauth2' ); ?>
 						</p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">
+						<label for="oauth-token-ttl"><?php echo esc_html_x( 'Token TTL (seconds)', 'field name', 'oauth2' ); ?></label>
+					</th>
+					<td>
+						<input type="number" class="regular-text" name="token_ttl" id="oauth-token-ttl" value="<?php echo esc_attr( $data['token_ttl'] ); ?>" min="0" />
+						<p class="description"><?php esc_html_e( 'Time-to-live for client credentials tokens in seconds. Leave empty for tokens that do not expire.', 'oauth2' ); ?></p>
 					</td>
 				</tr>
 			</table>

--- a/inc/authentication/namespace.php
+++ b/inc/authentication/namespace.php
@@ -8,6 +8,7 @@
 namespace WP\OAuth2\Authentication;
 
 use WP_Error;
+use WP_Http;
 use WP_User;
 use WP\OAuth2\Tokens;
 
@@ -176,7 +177,7 @@ function attempt_authentication( $user = null ) {
 			'oauth2.authentication.token_expired',
 			__( 'Access token has expired.', 'oauth2' ),
 			[
-				'status' => \WP_Http::UNAUTHORIZED,
+				'status' => WP_Http::UNAUTHORIZED,
 			]
 		);
 		return $user;

--- a/inc/authentication/namespace.php
+++ b/inc/authentication/namespace.php
@@ -169,6 +169,19 @@ function attempt_authentication( $user = null ) {
 		return $user;
 	}
 
+	// Reject expired tokens before any further lookups.
+	if ( $token->is_expired() ) {
+		$is_querying_token = false;
+		$oauth2_error      = new WP_Error(
+			'oauth2.authentication.token_expired',
+			__( 'Access token has expired.', 'oauth2' ),
+			[
+				'status' => \WP_Http::UNAUTHORIZED,
+			]
+		);
+		return $user;
+	}
+
 	$client            = $token->get_client();
 	$is_querying_token = false;
 

--- a/inc/class-client.php
+++ b/inc/class-client.php
@@ -20,6 +20,7 @@ class Client implements ClientInterface {
 	const TYPE_KEY                       = '_oauth2_client_type';
 	const REDIRECT_URI_KEY               = '_oauth2_redirect_uri';
 	const CLIENT_CREDENTIALS_ENABLED_KEY = '_oauth2_client_credentials_enabled';
+	const TOKEN_TTL_KEY                  = '_oauth2_client_token_ttl';
 	const AUTH_CODE_KEY_PREFIX           = '_oauth2_authcode_';
 	const AUTH_CODE_LENGTH               = 12;
 	const CLIENT_ID_LENGTH               = 12;
@@ -140,6 +141,21 @@ class Client implements ClientInterface {
 	 */
 	public function is_client_credentials_enabled() {
 		return (bool) get_post_meta( $this->get_post_id(), static::CLIENT_CREDENTIALS_ENABLED_KEY, true );
+	}
+
+	/**
+	 * Get the token TTL for client credentials tokens.
+	 *
+	 * @return int|null TTL in seconds, or null if tokens should not expire.
+	 */
+	public function get_token_ttl() {
+		$ttl = get_post_meta( $this->get_post_id(), static::TOKEN_TTL_KEY, true );
+
+		if ( $ttl === '' || $ttl === false ) {
+			return null;
+		}
+
+		return (int) $ttl;
 	}
 
 	/**
@@ -363,6 +379,10 @@ class Client implements ClientInterface {
 			static::CLIENT_CREDENTIALS_ENABLED_KEY => ! empty( $data['meta']['client_credentials_enabled'] ) ? '1' : '',
 		];
 
+		if ( isset( $data['meta']['token_ttl'] ) && $data['meta']['token_ttl'] !== '' ) {
+			$meta[ static::TOKEN_TTL_KEY ] = (int) $data['meta']['token_ttl'];
+		}
+
 		foreach ( $meta as $key => $value ) {
 			$result = update_post_meta( $post_id, wp_slash( $key ), wp_slash( $value ) );
 			if ( ! $result ) {
@@ -399,6 +419,12 @@ class Client implements ClientInterface {
 			static::TYPE_KEY                       => $data['meta']['type'],
 			static::CLIENT_CREDENTIALS_ENABLED_KEY => ! empty( $data['meta']['client_credentials_enabled'] ) ? '1' : '',
 		];
+
+		if ( isset( $data['meta']['token_ttl'] ) && $data['meta']['token_ttl'] !== '' ) {
+			$meta[ static::TOKEN_TTL_KEY ] = (int) $data['meta']['token_ttl'];
+		} else {
+			$meta[ static::TOKEN_TTL_KEY ] = '';
+		}
 
 		foreach ( $meta as $key => $value ) {
 			update_post_meta( $post_id, wp_slash( $key ), wp_slash( $value ) );

--- a/inc/endpoints/class-token.php
+++ b/inc/endpoints/class-token.php
@@ -178,9 +178,12 @@ class Token {
 			return $token;
 		}
 
+		$ttl = apply_filters( 'oauth2.client_token_ttl', OAuth2\Tokens\Access_Token::DEFAULT_CLIENT_TOKEN_TTL );
+
 		return [
 			'access_token' => $token->get_key(),
 			'token_type'   => 'bearer',
+			'expires_in'   => $ttl,
 		];
 	}
 

--- a/inc/endpoints/class-token.php
+++ b/inc/endpoints/class-token.php
@@ -178,13 +178,17 @@ class Token {
 			return $token;
 		}
 
-		$ttl = apply_filters( 'oauth2.client_token_ttl', OAuth2\Tokens\Access_Token::DEFAULT_CLIENT_TOKEN_TTL );
-
-		return [
+		$data = [
 			'access_token' => $token->get_key(),
 			'token_type'   => 'bearer',
-			'expires_in'   => $ttl,
 		];
+
+		$expires = $token->get_expiration_time();
+		if ( $expires !== null ) {
+			$data['expires_in'] = $expires - time();
+		}
+
+		return $data;
 	}
 
 	/**

--- a/inc/tokens/class-access-token.php
+++ b/inc/tokens/class-access-token.php
@@ -15,9 +15,9 @@ use WP_User;
 use WP_User_Query;
 
 class Access_Token extends Token {
-	const META_PREFIX              = '_oauth2_access_';
-	const CLIENT_META_PREFIX       = '_oauth2_client_token_';
-	const KEY_LENGTH               = 12;
+	const META_PREFIX = '_oauth2_access_';
+	const KEY_LENGTH = 12;
+	const CLIENT_META_PREFIX = '_oauth2_client_token_';
 
 	/**
 	 * @return string Meta prefix. Client tokens use a distinct prefix because

--- a/inc/tokens/class-access-token.php
+++ b/inc/tokens/class-access-token.php
@@ -18,7 +18,6 @@ class Access_Token extends Token {
 	const META_PREFIX              = '_oauth2_access_';
 	const CLIENT_META_PREFIX       = '_oauth2_client_token_';
 	const KEY_LENGTH               = 12;
-	const DEFAULT_CLIENT_TOKEN_TTL = 3600; // 1 hour in seconds
 
 	/**
 	 * @return string Meta prefix. Client tokens use a distinct prefix because
@@ -276,13 +275,16 @@ class Access_Token extends Token {
 			);
 		}
 
-		$ttl  = apply_filters( 'oauth2.client_token_ttl', static::DEFAULT_CLIENT_TOKEN_TTL );
+		$ttl  = $client->get_token_ttl();
 		$data = [
 			'client'  => $client->get_id(),
 			'created' => time(),
-			'expires' => time() + $ttl,
 			'meta'    => $meta,
 		];
+
+		if ( $ttl !== null ) {
+			$data['expires'] = time() + $ttl;
+		}
 		$key      = wp_generate_password( static::KEY_LENGTH, false );
 		$meta_key = static::CLIENT_META_PREFIX . $key;
 

--- a/inc/tokens/class-access-token.php
+++ b/inc/tokens/class-access-token.php
@@ -15,9 +15,10 @@ use WP_User;
 use WP_User_Query;
 
 class Access_Token extends Token {
-	const META_PREFIX        = '_oauth2_access_';
-	const CLIENT_META_PREFIX = '_oauth2_client_token_';
-	const KEY_LENGTH         = 12;
+	const META_PREFIX              = '_oauth2_access_';
+	const CLIENT_META_PREFIX       = '_oauth2_client_token_';
+	const KEY_LENGTH               = 12;
+	const DEFAULT_CLIENT_TOKEN_TTL = 3600; // 1 hour in seconds
 
 	/**
 	 * @return string Meta prefix. Client tokens use a distinct prefix because
@@ -275,9 +276,11 @@ class Access_Token extends Token {
 			);
 		}
 
-		$data     = [
+		$ttl  = apply_filters( 'oauth2.client_token_ttl', static::DEFAULT_CLIENT_TOKEN_TTL );
+		$data = [
 			'client'  => $client->get_id(),
 			'created' => time(),
+			'expires' => time() + $ttl,
 			'meta'    => $meta,
 		];
 		$key      = wp_generate_password( static::KEY_LENGTH, false );
@@ -306,11 +309,36 @@ class Access_Token extends Token {
 	}
 
 	/**
+	 * Check if the token has expired.
+	 *
+	 * Tokens without an `expires` timestamp never expire (backwards compat
+	 * for user tokens issued before expiry support was added).
+	 *
+	 * @return bool True if the token has expired, false otherwise.
+	 */
+	public function is_expired() {
+		if ( ! isset( $this->value['expires'] ) ) {
+			return false;
+		}
+
+		return time() >= $this->value['expires'];
+	}
+
+	/**
+	 * Get expiration timestamp.
+	 *
+	 * @return int|null Expiration timestamp, or null if no expiration.
+	 */
+	public function get_expiration_time() {
+		return $this->value['expires'] ?? null;
+	}
+
+	/**
 	 * Check if the token is valid.
 	 *
 	 * @return bool True if the token is valid, false otherwise.
 	 */
 	public function is_valid() {
-		return true;
+		return ! $this->is_expired();
 	}
 }


### PR DESCRIPTION
## Summary

- **Per-client TTL setting** — Each OAuth client can configure a token TTL (in seconds) via the admin UI. Existing clients default to no TTL (tokens never expire), preserving backwards compatibility.
- **Expiry stored on the token** — `Access_Token::create_for_client()` reads the TTL from the client and sets an `expires` timestamp on the token at creation time.
- **Expired token rejection** — The authentication layer rejects expired tokens with a `401 Unauthorized`.
- **`expires_in` in token response** — The `/oauth2/access_token` endpoint includes `expires_in` in the response only when the token actually has an expiry.

## Backwards Compatibility

Existing clients have no TTL stored — tokens issued to them will not expire. New clients opt in by setting a TTL value in the admin UI.