### PR TITLE
Allow composer/installers v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"composer/installers": "~1.0",
+		"composer/installers": "^1 || ^2",
 		"php": ">=7.4"
 	},
 	"require-dev": {


### PR DESCRIPTION
## Summary
Widens the `composer/installers` constraint from `~1.0` to `^1 || ^2`.

## Rationale
This plugin is a Composer package itself, so the constraint only matters for consumers installing it. There is no code dependency on the installer's API, and installers v1 is now deprecated — hosting ecosystems (e.g. newer Composer 2.x setups and updated WordPress project tooling) are moving to v2. Widening the range keeps installs working in both worlds.

## Validation
- Constraint change only; no source changes.
- Existing dev constraints and CI are unaffected.

@joehoyle could you take a look?