### PR TITLE
Accept HTTP Basic client credentials on the authorization_code grant

### DIFF
--- a/inc/endpoints/class-token.php
+++ b/inc/endpoints/class-token.php
@@ -72,6 +72,21 @@ class Token {
 			return $this->handle_client_credentials( $request );
 		}
 
+		// RFC 6749 section 2.3.1: a client may authenticate with HTTP Basic
+		// instead of body parameters. Body parameters take precedence.
+		if ( $request->get_param( 'client_id' ) === null || $request->get_param( 'client_id' ) === '' ) {
+			$basic = $this->get_basic_auth_credentials( $request );
+			if ( is_wp_error( $basic ) ) {
+				return $basic;
+			}
+			if ( null !== $basic ) {
+				$request->set_param( 'client_id', $basic[0] );
+				if ( $request->get_param( 'client_secret' ) === null || $request->get_param( 'client_secret' ) === '' ) {
+					$request->set_param( 'client_secret', $basic[1] );
+				}
+			}
+		}
+
 		// The authorization_code grant requires `client_id` and `code`.
 		// These are declared optional at the schema level so they don't
 		// apply to client_credentials, so validate presence here. The error
@@ -201,30 +216,9 @@ class Token {
 		}
 
 		// Fall back to Basic authentication from Authorization header
-		$auth_header = $request->get_header( 'authorization' );
-
-		if ( ! empty( $auth_header ) && stripos( $auth_header, 'Basic ' ) === 0 ) {
-			$encoded = substr( $auth_header, 6 );
-			$decoded = base64_decode( $encoded, true );
-
-			if ( false === $decoded ) {
-				return new WP_Error(
-					'oauth2.endpoints.token.invalid_request',
-					__( 'Invalid Authorization header.', 'oauth2' ),
-					[ 'status' => WP_Http::BAD_REQUEST ]
-				);
-			}
-
-			$parts = explode( ':', $decoded, 2 );
-			if ( count( $parts ) !== 2 ) {
-				return new WP_Error(
-					'oauth2.endpoints.token.invalid_request',
-					__( 'Invalid Authorization header format.', 'oauth2' ),
-					[ 'status' => WP_Http::BAD_REQUEST ]
-				);
-			}
-
-			return [ trim( $parts[0] ), trim( $parts[1] ) ];
+		$basic = $this->get_basic_auth_credentials( $request );
+		if ( null !== $basic ) {
+			return $basic;
 		}
 
 		return new WP_Error(
@@ -232,5 +226,42 @@ class Token {
 			__( 'Client credentials not provided.', 'oauth2' ),
 			[ 'status' => WP_Http::BAD_REQUEST ]
 		);
+	}
+
+	/**
+	 * Read client credentials from an HTTP Basic Authorization header.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array|WP_Error|null Array with client_id and client_secret, error if the
+	 *                             header is malformed, or null if there is no Basic header.
+	 */
+	private function get_basic_auth_credentials( WP_REST_Request $request ) {
+		$auth_header = $request->get_header( 'authorization' );
+
+		if ( empty( $auth_header ) || stripos( $auth_header, 'Basic ' ) !== 0 ) {
+			return null;
+		}
+
+		$encoded = substr( $auth_header, 6 );
+		$decoded = base64_decode( $encoded, true );
+
+		if ( false === $decoded ) {
+			return new WP_Error(
+				'oauth2.endpoints.token.invalid_request',
+				__( 'Invalid Authorization header.', 'oauth2' ),
+				[ 'status' => WP_Http::BAD_REQUEST ]
+			);
+		}
+
+		$parts = explode( ':', $decoded, 2 );
+		if ( count( $parts ) !== 2 ) {
+			return new WP_Error(
+				'oauth2.endpoints.token.invalid_request',
+				__( 'Invalid Authorization header format.', 'oauth2' ),
+				[ 'status' => WP_Http::BAD_REQUEST ]
+			);
+		}
+
+		return [ trim( $parts[0] ), trim( $parts[1] ) ];
 	}
 }

--- a/inc/endpoints/class-token.php
+++ b/inc/endpoints/class-token.php
@@ -262,6 +262,8 @@ class Token {
 			);
 		}
 
-		return [ trim( $parts[0] ), trim( $parts[1] ) ];
+		// RFC 6749 section 2.3.1: both values are form-encoded before they go
+		// into the header, so decode them on the way back out.
+		return [ urldecode( trim( $parts[0] ) ), urldecode( trim( $parts[1] ) ) ];
 	}
 }

--- a/tests/test-token-endpoint.php
+++ b/tests/test-token-endpoint.php
@@ -133,6 +133,52 @@ class Test_Token_Endpoint extends Test_Case {
 		$this->assertEquals( 'bearer', $data['token_type'] );
 	}
 
+	public function test_exchange_token_client_id_via_basic_auth_header() {
+		$user    = $this->factory->user->create_and_get();
+		$code    = Authorization_Code::create( $this->client, $user );
+		$encoded = base64_encode( $this->client->get_id() . ':' . $this->client->get_secret() );
+
+		$request = new WP_REST_Request( 'POST', '/oauth2/access_token' );
+		$request->set_param( 'grant_type', 'authorization_code' );
+		$request->set_param( 'code', $code->get_code() );
+		$request->add_header( 'Authorization', 'Basic ' . $encoded );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'access_token', $data );
+	}
+
+	public function test_exchange_token_body_client_id_takes_precedence_over_basic_auth_header() {
+		$user    = $this->factory->user->create_and_get();
+		$code    = Authorization_Code::create( $this->client, $user );
+		$encoded = base64_encode( 'nonexistent-client:any-secret' );
+
+		$request = new WP_REST_Request( 'POST', '/oauth2/access_token' );
+		$request->set_param( 'grant_type', 'authorization_code' );
+		$request->set_param( 'client_id', $this->client->get_id() );
+		$request->set_param( 'code', $code->get_code() );
+		$request->add_header( 'Authorization', 'Basic ' . $encoded );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_exchange_token_invalid_basic_auth_header() {
+		$request = new WP_REST_Request( 'POST', '/oauth2/access_token' );
+		$request->set_param( 'grant_type', 'authorization_code' );
+		$request->set_param( 'code', 'somecode' );
+		$request->add_header( 'Authorization', 'Basic not-valid-base64!!!' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'oauth2.endpoints.token.invalid_request', $data['code'] );
+	}
+
 	public function test_exchange_token_deletes_code_after_use() {
 		$user = $this->factory->user->create_and_get();
 		$code = Authorization_Code::create( $this->client, $user );

--- a/tests/test-token-endpoint.php
+++ b/tests/test-token-endpoint.php
@@ -231,6 +231,26 @@ class Test_Token_Endpoint extends Test_Case {
 		$this->assertArrayHasKey( 'access_token', $data );
 	}
 
+	public function test_client_credentials_basic_auth_header_is_form_decoded() {
+		$client = $this->create_client( [ 'client_credentials_enabled' => true ] );
+		$secret = 'a b+c';
+		update_post_meta( $client->get_post_id(), Client::CLIENT_SECRET_KEY, $secret );
+
+		// Per RFC 6749 section 2.3.1 the client form-encodes both values, so a
+		// space arrives as "+" and a literal "+" as "%2B".
+		$encoded = base64_encode( urlencode( $client->get_id() ) . ':' . urlencode( $secret ) );
+
+		$request = new WP_REST_Request( 'POST', '/oauth2/access_token' );
+		$request->set_param( 'grant_type', 'client_credentials' );
+		$request->add_header( 'Authorization', 'Basic ' . $encoded );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'access_token', $data );
+	}
+
 	public function test_client_credentials_wrong_secret() {
 		$client = $this->create_client( [ 'client_credentials_enabled' => true ] );
 


### PR DESCRIPTION
A client that authenticates at the token endpoint with HTTP Basic auth, which RFC 6749 section 2.3.1 recommends, gets "Missing parameter(s): client_id" on the authorization_code grant. The client_credentials grant already reads the header. The authorization_code grant only looked at body parameters.

Both the MCP connector and Claude Code authenticate this way, and both failed the exchange against a site running this plugin. The site's RFC 8414 discovery document advertised `client_secret_basic`, so the clients were behaving correctly.

The header parsing is now shared between the two grants. On the authorization_code grant it only applies when the body has no `client_id`, so body parameters keep precedence. A malformed header returns the same `invalid_request` error the client_credentials grant already uses.

This does not verify `client_secret` on the authorization_code grant, which #36 covers.